### PR TITLE
Add default headers to all requests 

### DIFF
--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -102,6 +102,10 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 	// set query params
 	setQuery(req.URL, reqPars)
 
+	// set headers
+	req.Header.Add("Accept", `application/json`)
+	req.Header.Add("Content-Type", `application/json`)
+
 	// do the actual http call
 	res, err := s.Client.Do(req)
 	if err != nil {


### PR DESCRIPTION
This PR adds a `application/json` `Accept` and `Content-Type` headers to all requests made to the Looker API through the SDK. This will allow us to parse non-2xx responses from the API, and ultimately improve error handling in the SDK.

I have added the `Content-Type` header as this could be useful for other users of the SDK, as this branch may be used to raise a PR against the original repo. 
