### PR TITLE
Feat: Add structured error struct for non-2xx responses - Status Code Only 

### DIFF
--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -119,7 +119,10 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 			return fmt.Errorf("response error. status=%s. error parsing error body", res.Status)
 		}
 
-		return fmt.Errorf("response error. status=%s. error=%s", res.Status, string(b))
+		return ResponseError{
+			StatusCode: res.StatusCode,
+			Err:        fmt.Errorf("response error. status=%s. error=%s", res.Status, string(b)),
+		}
 	}
 
 	// TODO: Make parsing content-type aware. Requires change to go model generation to use interface{} for all union types.

--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -114,15 +114,18 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 	defer res.Body.Close()
 
 	if res.StatusCode < 200 || res.StatusCode > 226 {
-		b, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return fmt.Errorf("response error. status=%s. error parsing error body", res.Status)
+		re := ResponseError{
+			StatusCode: res.StatusCode,
 		}
 
-		return ResponseError{
-			StatusCode: res.StatusCode,
-			Err:        fmt.Errorf("response error. status=%s. error=%s", res.Status, string(b)),
+		b, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			re.Err = fmt.Errorf("response error. status=%s. error parsing error body", res.Status)
+			return re
 		}
+		re.Err = fmt.Errorf("response error. status=%s. error=%s", res.Status, string(b))
+
+		return re
 	}
 
 	// TODO: Make parsing content-type aware. Requires change to go model generation to use interface{} for all union types.

--- a/go/rtl/errors.go
+++ b/go/rtl/errors.go
@@ -1,0 +1,10 @@
+package rtl
+
+type ResponseError struct {
+	StatusCode int
+	Err        error
+}
+
+func (e ResponseError) Error() string {
+	return e.Err.Error()
+}


### PR DESCRIPTION
## Description 

This PR adds a simple `ResponseError` struct which returns the raw error coming from the Looker API alongside the status code. This will allow any users of the SDK to inspect any non-200 status codes coming back from the SDK. 

Note: **This PR has the least impact on the SDK and is the simplest change we can make to provide the status code. This change does not parse or unmarshal the json error.**
